### PR TITLE
Removed jquery dependecy from keyboard plugin and corrected tests

### DIFF
--- a/js/plugins/std.keyboard.js
+++ b/js/plugins/std.keyboard.js
@@ -15,11 +15,9 @@
 /*global define, require */
 
 define([
-	"jquery",
 	"../core/util",
 	"../core/classes/iodev/keyboard/scancode"
 ], function (
-	$,
 	util,
 	Scancode
 ) {
@@ -28,7 +26,7 @@ define([
 	var keyboardPlugin = {
 		applyTo: function (emu) {
 			var cancelKeypress = false;
-			$(util.global.document).keydown(function (evt) {
+			util.global.document.addEventListener("keydown", function (evt) {
 				var key = toKeyIndex(evt.keyCode);
 
 				// Simple translation to KEY_* values (needs a keymap)
@@ -38,12 +36,14 @@ define([
 				cancelKeypress = true;
 				evt.preventDefault();
 				return false;
-			}).keyup(function (evt) {
+			});
+			util.global.document.addEventListener("keyup", function (evt) {
 				var key = toKeyIndex(evt.keyCode);
 
 				// Simple translation to KEY_* values (needs a keymap)
 				emu.machine.keyboard.keyboard.generateScancode(key, "break");
-			}).keypress(function (evt) {
+			})
+			util.global.document.addEventListener("keypress", function (evt) {
 				if ( cancelKeypress ) {
 					cancelKeypress = false; // Only this keypress
 					evt.preventDefault();

--- a/tests/bdd/unit/js/plugins/std.keyboardTest.js
+++ b/tests/bdd/unit/js/plugins/std.keyboardTest.js
@@ -13,28 +13,35 @@
 
 /*global afterEach, beforeEach, define, describe, expect, it, sinon */
 define([
-    "jquery",
     "modular",
     "require",
     "js/core/util"
 ], function (
-    $,
     modular,
     require,
     rootUtil
 ) {
     "use strict";
 
+     function createEvent(eventName, keyCode){
+        var event = document.createEvent('Event');
+        
+        event.initEvent(eventName, true, true);
+        event.keyCode = keyCode;
+        event.isDefaultPrevented = function(){
+            return this.defaultPrevented;
+        };
+        
+        return event;
+    }
+    
     describe("Standard Keyboard plugin", function () {
-        var document,
-            emu,
+        var emu,
             event,
             generateScancode,
-            mock,
             util;
 
         beforeEach(function (done) {
-            document = {};
             generateScancode = sinon.spy();
 
             emu = {
@@ -61,9 +68,6 @@ define([
                 var mockModular = new Modular(),
                     define = mockModular.createDefiner();
 
-                define("jquery", function () {
-                    return $;
-                });
                 define("../../js/core/util", util);
 
                 mockModular.createRequirer()(rootUtil.extend({}, modular.configure(), {
@@ -123,9 +127,9 @@ define([
             describe("for key with keyCode " + fixture.keyCode + " (" + fixture.keyName + ")", function () {
                 describe("when a 'keydown' event fires", function () {
                     beforeEach(function () {
-                        event = new $.Event("keydown", { keyCode: fixture.keyCode });
-
-                        $(document).trigger(event);
+                        event = createEvent("keydown", fixture.keyCode);
+                        
+                        document.dispatchEvent(event);
                     });
 
                     it("should generate a 'make' scancode", function () {
@@ -143,9 +147,9 @@ define([
 
                 describe("when a 'keyup' event fires", function () {
                     beforeEach(function () {
-                        event = new $.Event("keyup", { keyCode: fixture.keyCode });
-
-                        $(document).trigger(event);
+                        event = createEvent("keyup", fixture.keyCode);
+                        
+                        document.dispatchEvent(event);
                     });
 
                     it("should generate a 'break' scancode", function () {


### PR DESCRIPTION
Hi Dan,
sory for obtrusiveness, I just want to speed up jemul8, if remove jquery dependency or move out it to google cdn if would work a little bit faster. Any way you use it in a couple places and wanted to remove it, as you write in todo of [util.js](https://github.com/asmblah/jemul8/blob/master/js/core/util.js#L29)

Corrected tests for pull request https://github.com/asmblah/jemul8/pull/8.
Tests works fine in Chrome and FF.
